### PR TITLE
Modified user route for handling empty request to verify-user-signup page

### DIFF
--- a/routes/user.js
+++ b/routes/user.js
@@ -166,7 +166,15 @@ router.post('/signup',(req,res)=>{
 
 router.get('/verify-user-signup', (req,res)=>{
 
-  res.render('user/sign-in-otp-validation',{title:PLATFORM_NAME + " || Verify Sign-Up OTP", user:true});
+  if(req.session.userSignupData){
+
+    res.render('user/sign-in-otp-validation',{title:PLATFORM_NAME + " || Verify Sign-Up OTP", user:true});
+
+  }else{
+
+    res.redirect('/signup');
+
+  }
 
 })
 


### PR DESCRIPTION
Prevented rendering the OTP Verification page if the user tries to access it without filling out the sign-up form.